### PR TITLE
Fixed critical issues with SAT ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 mediancut
 =========
 
-This is an implementation of Paul Debevec's [A Median Cut Algorithm for Light Probe Sampling](http://gl.ict.usc.edu/Research/MedianCut/). The code generates sample positions for 2^n light sources. You will still need to sum up the energy of the respective cut region to get the final flux. To run the sample, please fetch [Sean Barrett's stb_image](http://nothings.org/).
+This is an implementation of Paul Debevec's [A Median Cut Algorithm for Light Probe Sampling](https://vgl.ict.usc.edu/Research/MedianCut/). The code generates sample positions for 2^n light sources. You will still need to sum up the energy of the respective cut region to get the final flux. To run the sample, please fetch [Sean Barrett's stb_image](http://nothings.org/).


### PR DESCRIPTION
Summary:
- The split loops were (potentially) producing 0-sized regions.
- The SAT sum was wrong by one row and one column.